### PR TITLE
Change time data types and adds import rake task

### DIFF
--- a/db/activities.csv
+++ b/db/activities.csv
@@ -1,0 +1,13 @@
+Title,Time Requirement,Cost?,Type
+Outdoor Walk,60,FALSE,Outdoor
+Hiking,90,FALSE,Outdoor
+Bubble Bath,30,FALSE,Beauty
+Face Mask,30,TRUE,Beauty
+Manicure,60,TRUE,Beauty
+Indoor Yoga,60,FALSE,Exercise
+Clean Out Sock Drawer,30,FALSE,Home
+Arrange Book Shelf,30,FALSE,Organizing
+Make A Special Meal,60,TRUE,Food
+5 Minute Breathing Exercise,30,FALSE,Mindfulness
+Yoga In The Park,60,FALSE,Group
+One Hour Of Reading,60,FALSE,Enrichment

--- a/db/categories.csv
+++ b/db/categories.csv
@@ -1,0 +1,11 @@
+Type
+Outdoor
+Beauty
+Exercise
+Home
+Organizing
+Food
+Mindfulness
+Group
+Event
+Enrichment

--- a/db/migrate/20200405171321_remove_self_care_from_users.rb
+++ b/db/migrate/20200405171321_remove_self_care_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveSelfCareFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :self_care_time, :integer
+    add_column :users, :self_care_time, :interval
+  end
+end

--- a/db/migrate/20200406164103_remove_self_care_type_from_users.rb
+++ b/db/migrate/20200406164103_remove_self_care_type_from_users.rb
@@ -1,0 +1,6 @@
+class RemoveSelfCareTypeFromUsers < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :users, :self_care_time, :interval
+    add_column :users, :self_care_time, :integer
+  end
+end

--- a/db/migrate/20200406164156_remove_esttime_from_activities.rb
+++ b/db/migrate/20200406164156_remove_esttime_from_activities.rb
@@ -1,0 +1,6 @@
+class RemoveEsttimeFromActivities < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :activities, :est_time, :time
+    add_column :activities, :est_time, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_03_011120) do
+ActiveRecord::Schema.define(version: 2020_04_05_171321) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,9 +49,9 @@ ActiveRecord::Schema.define(version: 2020_04_03_011120) do
     t.string "last_name"
     t.string "email"
     t.string "google_token"
-    t.integer "self_care_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.interval "self_care_time"
   end
 
   add_foreign_key "category_activities", "activities"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_05_171321) do
+ActiveRecord::Schema.define(version: 2020_04_06_164156) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "activities", force: :cascade do |t|
     t.string "name"
-    t.time "est_time"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "est_time"
   end
 
   create_table "categories", force: :cascade do |t|
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 2020_04_05_171321) do
     t.string "google_token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.interval "self_care_time"
+    t.integer "self_care_time"
   end
 
   add_foreign_key "category_activities", "activities"

--- a/lib/tasks/import.rake
+++ b/lib/tasks/import.rake
@@ -1,0 +1,20 @@
+require 'csv'
+desc "Import data from jsom files"
+task :import => [:environment] do
+
+  Category.destroy_all
+  Activity.destroy_all
+
+  categories = "db/categories.csv"
+  activites = 'db/activities.csv'
+
+  CSV.foreach(categories, headers: true) do |row|
+    Category.create( name: row['Type']  )
+  end
+
+  CSV.foreach(activites, headers: true) do |row|
+    category = Category.where(name: row['Type'])
+    activity = Activity.create(name: row['Title'], est_time: row['Time Requirement'])
+    activity.categories << category
+  end
+end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #20 

### Problem Addressed
Needed a simple and consistent way to store time in the database and also a way to quickly import seed data.
### Solution Implemented
Changed user self_care_time and activity est_time to an integer in database. Also created rake task to import seed data
### Other Notes
