### PR TITLE
Create and Delete mutations for a user's activities

### DIFF
--- a/app/graphql/mutations/users/create_user_activities.rb
+++ b/app/graphql/mutations/users/create_user_activities.rb
@@ -1,0 +1,23 @@
+module Mutations
+  module Users
+    class CreateUserActivities < ::Mutations::BaseMutation
+      argument :id, ID, required: true
+      argument :categories, [String], required: true
+
+      type Types::UserType
+
+      def resolve(attributes)
+        user = User.find(attributes[:id])
+
+        category_ids = attributes[:categories].map do |name|
+          category = Category.find_by(name: name)
+          category.id
+        end
+
+        activities = CategoryActivity.where(category_id: [category_ids])
+        user.category_activities << activities
+        user
+      end
+    end
+  end
+end

--- a/app/graphql/mutations/users/delete_user_activity.rb
+++ b/app/graphql/mutations/users/delete_user_activity.rb
@@ -1,0 +1,21 @@
+module Mutations
+  module Users
+    class DeleteUserActivity < ::Mutations::BaseMutation
+
+      argument :id, ID, required: true
+      argument :activity, String, required: true
+
+      type Types::UserType
+
+      def resolve(attributes)
+        user = User.find(attributes[:id])
+        activity = Activity.find_by(name: attributes[:activity])
+        category_activity = CategoryActivity.find_by(activity_id: activity.id)
+
+        user_activity = UserActivity.find_by(category_activity_id: category_activity.id)
+        user_activity.destroy
+        user
+      end
+    end
+  end
+end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -2,5 +2,6 @@ module Types
   class MutationType < Types::BaseObject
     field :create_user, mutation: Mutations::Users::CreateUser
     field :create_user_activities, mutation: Mutations::Users::CreateUserActivities
+    field :delete_user_activity, mutation: Mutations::Users::DeleteUserActivity
   end
 end

--- a/app/graphql/types/mutation_type.rb
+++ b/app/graphql/types/mutation_type.rb
@@ -1,5 +1,6 @@
 module Types
   class MutationType < Types::BaseObject
     field :create_user, mutation: Mutations::Users::CreateUser
+    field :create_user_activities, mutation: Mutations::Users::CreateUserActivities
   end
 end

--- a/spec/graphql/mutations/users/create_user_activities_spec.rb
+++ b/spec/graphql/mutations/users/create_user_activities_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+module Mutations
+  module Users
+
+    RSpec.describe CreateUserActivities, type: :request do
+
+      it 'create a user and activities' do
+  			user = User.create(id: 114, first_name: "Sue", last_name: "Buckets", email: "suebuckets@gmail.com", google_token: "018723y4kjd" )
+        category = Category.create(name: "Outdoors")
+        category2 = Category.create(name: "Spa")
+
+        activity1 = Activity.create(name: "Hike", est_time: "01:15")
+        activity2 = Activity.create(name: "Bike Ride", est_time: "01:15")
+        activity3 = Activity.create(name: "Facial", est_time: "01:15")
+        activity4 = Activity.create(name: "Pedicure", est_time: "01:15")
+        category.activities << [activity1, activity2]
+        category.activities << [activity3, activity4]
+
+
+  			result = TreatYoSelfSchema.execute(query).as_json
+        activities = [activity1.name, activity2.name, activity3.name, activity4.name]
+        expect(result["data"]["user"]["activities"]).to eq(activities)
+		  end
+		def query
+      <<~GQL
+        mutation {
+          user: createUserActivities(
+            input: { id: "114"
+                     categories: ["Outdoors", "Spa"]
+                      }  )
+        {
+          activities
+          }
+        }
+      GQL
+		end
+    end
+	end
+end

--- a/spec/graphql/mutations/users/delete_user_activity_spec.rb
+++ b/spec/graphql/mutations/users/delete_user_activity_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+module Mutations
+  module Users
+
+    RSpec.describe DeleteUserActivity, type: :request do
+
+      it 'delete an activity belonging to a user' do
+  			user = User.create(id: 115, first_name: "Sue", last_name: "Buckets", email: "suebuckets@gmail.com", google_token: "018723y4kjd" )
+        category = Category.create(name: "Outdoors")
+
+        activity1 = Activity.create(name: "Hike", est_time: "01:15")
+        activity2 = Activity.create(name: "Bike Ride", est_time: "01:15")
+        activity3 = Activity.create(name: "Facial", est_time: "01:15")
+        activity4 = Activity.create(name: "Pedicure", est_time: "01:15")
+        category.activities << [activity1, activity2, activity3, activity4]
+        categoryactivities = CategoryActivity.all
+        user.category_activities << categoryactivities
+
+        expect(Activity.count).to eq(4)
+        expect(user.category_activities.count).to eq(4)
+
+  			result = TreatYoSelfSchema.execute(query).as_json
+
+        # verifies that the activity is not deleted from database.
+        expect(Activity.count).to eq(4)
+        expect(user.category_activities.count).to eq(3)
+
+        #array does not include activity 1 which should be deleted from user activities
+        activities = [activity2.name, activity3.name, activity4.name]
+        expect(result["data"]["user"]["activities"]).to eq(activities)
+
+		  end
+		def query
+      <<~GQL
+        mutation {
+          user: deleteUserActivity(
+            input: { id: "115"
+                     activity: "Hike"
+                      }  )
+        {
+          activities
+          }
+        }
+      GQL
+		end
+    end
+	end
+end


### PR DESCRIPTION
### Sidebar Checklist

- [x] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #

### Problem Addressed
Don't have a way for a user to pick categories and the BE to then associate those activities to their account. If a user doesn't like an activity there is no way to delete that from their account. 
### Solution Implemented
Creates a create_user_activities and delete_user_activity mutation query for the front end to send to the BE. 
### Other Notes
Added testing and added queries to the docs. 