### PR TITLE
Get delights endpoint to return 5 suggestions in a specified category, regardless of preferences

### DIFF
--- a/app/graphql/types/query_type.rb
+++ b/app/graphql/types/query_type.rb
@@ -17,6 +17,9 @@ module Types
 
     field :get_activities, [Types::ActivityType], null: false, description: "returns all categories"
 
+    field :get_delights, [Types::ActivityType], null: false, description: "returns a set of activities" do
+      argument :id, ID, required: true
+    end
 
     # resolvers below/controller actions
 
@@ -35,10 +38,15 @@ module Types
 
     def get_category_activities(id:)
       Category.find_by(name: id)
-    end 
+    end
 
-    def get_activities 
+    def get_activities
       Activity.all
+    end
+
+    def get_delights(id:)
+      cat_name = Category.find(id)
+      possibilities = cat_name.activities.sample(5)
     end
   end
 end

--- a/spec/graphql/queries/activity/get_delight_spec.rb
+++ b/spec/graphql/queries/activity/get_delight_spec.rb
@@ -23,6 +23,15 @@ RSpec.describe Types::QueryType do
 			result = TreatYoSelfSchema.execute(query).as_json
 			expect(result["data"]["getDelights"].count).to eq(3)
       expect(result["data"]["getDelights"].count).not_to eq(6)
+
+			activity_1 = Activity.create(name: "Plant Trees", est_time: 90)
+			activity_2 = Activity.create(name: "Rock Climbing", est_time: 180)
+			activity_3 = Activity.create(name: "Sit in a Park", est_time: 30)
+			joins1 = CategoryActivity.create(category_id: category.id, activity_id: activity_1.id)
+			joins2 = CategoryActivity.create(category_id: category.id, activity_id: activity_2.id)
+			joins3 = CategoryActivity.create(category_id: category.id, activity_id: activity_3.id)
+			result = TreatYoSelfSchema.execute(query).as_json
+			expect(result["data"]["getDelights"].count).to eq(5)
     end
     def query
       <<~GQL

--- a/spec/graphql/queries/activity/get_delight_spec.rb
+++ b/spec/graphql/queries/activity/get_delight_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe Types::QueryType do
+	describe 'find an activity' do
+		it 'can get a single activity' do
+      category = Category.create(id: 111, name: "Outdoors")
+      activity1 = Activity.create(name: "Walk", est_time: 90)
+      activity2 = Activity.create(name: "Hike", est_time: 180)
+			activity3 = Activity.create(name: "Sit by the river", est_time: 30)
+			joins1 = CategoryActivity.create(category_id: category.id, activity_id: activity1.id)
+			joins2 = CategoryActivity.create(category_id: category.id, activity_id: activity2.id)
+			joins3 = CategoryActivity.create(category_id: category.id, activity_id: activity3.id)
+
+
+
+			result = TreatYoSelfSchema.execute(query).as_json
+      expect(result["data"]["getDelights"].count).to eq(3)
+    end
+    def query
+      <<~GQL
+      {
+        getDelights(id: "111")
+        {
+          id
+          name
+        }
+      }
+      GQL
+    end
+  end
+end

--- a/spec/graphql/queries/activity/get_delight_spec.rb
+++ b/spec/graphql/queries/activity/get_delight_spec.rb
@@ -30,8 +30,10 @@ RSpec.describe Types::QueryType do
 			joins1 = CategoryActivity.create(category_id: category.id, activity_id: activity_1.id)
 			joins2 = CategoryActivity.create(category_id: category.id, activity_id: activity_2.id)
 			joins3 = CategoryActivity.create(category_id: category.id, activity_id: activity_3.id)
+
 			result = TreatYoSelfSchema.execute(query).as_json
 			expect(result["data"]["getDelights"].count).to eq(5)
+			expect(result["data"]["getDelights"].count).not_to eq(6)
     end
     def query
       <<~GQL

--- a/spec/graphql/queries/activity/get_delight_spec.rb
+++ b/spec/graphql/queries/activity/get_delight_spec.rb
@@ -11,10 +11,18 @@ RSpec.describe Types::QueryType do
 			joins2 = CategoryActivity.create(category_id: category.id, activity_id: activity2.id)
 			joins3 = CategoryActivity.create(category_id: category.id, activity_id: activity3.id)
 
+			category2 = Category.create(id: 112, name: "Mindfulness")
+			activity_a = Activity.create(name: "Yoga", est_time: 90)
+			activity_b = Activity.create(name: "Journaling", est_time: 180)
+			activity_c = Activity.create(name: "Listen to David Arkenstone", est_time: 30)
+			joins_a = CategoryActivity.create(category_id: category2.id, activity_id: activity_a.id)
+			joins_b = CategoryActivity.create(category_id: category2.id, activity_id: activity_b.id)
+			joins_c = CategoryActivity.create(category_id: category2.id, activity_id: activity_c.id)
 
 
 			result = TreatYoSelfSchema.execute(query).as_json
-      expect(result["data"]["getDelights"].count).to eq(3)
+			expect(result["data"]["getDelights"].count).to eq(3)
+      expect(result["data"]["getDelights"].count).not_to eq(6)
     end
     def query
       <<~GQL


### PR DESCRIPTION
### Sidebar Checklist

- [X] Request reviewers
- [x] Assign yourself and other contributors
- [x] Link to project

### Issues Resolved
Resolves #39 

### Problem Addressed
This is an extension that allows users to look at treats that exist in categories they may not have chosen or have not shown interest in.
### Solution Implemented
Graphql query that return 5 (or less if there are less items in the category) treats.
### Other Notes
This will not be connected to the FE most likely, due to time constraints. This will be an ice box feature, but was completed to help round out graphql comprehension.